### PR TITLE
Changed infohash to always be lowercase when it's a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function magnetURIDecode (uri) {
     var xts = Array.isArray(result.xt) ? result.xt : [ result.xt ]
     xts.forEach(function (xt) {
       if ((m = xt.match(/^urn:btih:(.{40})/))) {
-        result.infoHash = m[1]
+        result.infoHash = m[1].toLowerCase()
       } else if ((m = xt.match(/^urn:btih:(.{32})/))) {
         var decodedStr = base32.decode(m[1])
         result.infoHash = new Buffer(decodedStr, 'binary').toString('hex')


### PR DESCRIPTION
This is in order to fix cases where the infoHash in the magnetUri is in uppercase.
In the context of webtorrent, this is problematic in the bittorrent-swarm peer object. Specifically, in Peer.prototype.onHandshake:

    if (infoHash !== self.swarm.infoHash) {
      return self.destroy(new Error('unexpected handshake info hash for this swarm'))
    }

In the above edge-case, this causes all peer handshakes to fail. This PR fixes this case.
